### PR TITLE
Auto redirect to new URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,10 @@
 title: Islandora Collaboration Group
 description: Islandora Collaboration Group (ICG) is a group of colleges working to support and extend the Islandora tool through development, resource pooling and advocacy.
 google_analytics: 
-show_downloads: true
+show_downloads: false
 theme: jekyll-theme-slate
 encoding: UTF-8
 
 gems:
   - jekyll-mentions
+  - jekyll-redirect-from

--- a/index.md
+++ b/index.md
@@ -1,3 +1,7 @@
+---
+redirect_to: "https://islandora-collaboration-group.github.io/icg_information/"
+---
+
 # Islandora Collaboration Group (ICG)
 
 ## About Us


### PR DESCRIPTION
This seeks to automatically navigate users from islandora-collaboration-group.github.io to islandora-collaboration-group.github.io/icg_information.  Additionally it disables downloads on the redirected ghio page.  

this can be tested by visiting:  https://br2490.github.io/islandora-collaboration-group.github.io/.

tagging @dwk2 as lead.

